### PR TITLE
Поправил тесты в соответствии с изученным материалом на лекции

### DIFF
--- a/src/test/java/ru/urfu/weatherforecastbot/util/WeatherForecastFormatterImplTest.java
+++ b/src/test/java/ru/urfu/weatherforecastbot/util/WeatherForecastFormatterImplTest.java
@@ -72,6 +72,7 @@ class WeatherForecastFormatterImplTest {
         assertEquals(expected, actual);
     }
 
+    // не уверен, что данный тест нужен (может ли в действительности сервис прислать прогноз, но при этом пустой?)
     @Test
     @DisplayName("При пустом прогнозе погоды на сегодня должен возвращать только заголовок прогноза погоды")
     void givenTodayEmptyForecast_whenFormatTodayForecast_thenReturnOnlyHeader() {


### PR DESCRIPTION
1) перестал брать ожидаемое значение из основного кода приложения (теперь сравниваем с константами) 
2) стал проверять, что обработчик действительно вызывает сервис прогноза и форматировщик, а не просто отсылает сообщение (но при этом есть вопрос, см. комментарий строка 91 файла MessageHandlerImplTest.java) 
3) убрал частичное пересечение тестов (перестал проверять, что бот отправил сообщение именно тому же пользователю, вместо этого вынес в отдельный тест)